### PR TITLE
refactor(plugins): improve code quality and add async mutex refactori…

### DIFF
--- a/crates/app/src/error/mod.rs
+++ b/crates/app/src/error/mod.rs
@@ -63,6 +63,12 @@ impl From<EventError> for CoreError {
     }
 }
 
+impl From<crate::plugin::PluginError> for CoreError {
+    fn from(err: crate::plugin::PluginError) -> Self {
+        Self::Plugin(err.to_string())
+    }
+}
+
 impl From<SquirrelError> for CoreError {
     fn from(err: SquirrelError) -> Self {
         match err {

--- a/crates/app/src/plugin/mod.rs
+++ b/crates/app/src/plugin/mod.rs
@@ -1,19 +1,23 @@
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use async_trait::async_trait;
 use serde::{Serialize, Deserialize};
 use uuid::Uuid;
+use tracing::{debug, error, info, warn};
 use crate::error::Result;
 
 /// Plugin type definitions and traits
 mod types;
 /// Plugin discovery and loading functionality
 mod discovery;
+/// Plugin state persistence functionality
+mod state;
 
 pub use types::{CommandPlugin, UiPlugin, ToolPlugin, McpPlugin};
 pub use discovery::{PluginDiscovery, FileSystemDiscovery, PluginLoader};
+pub use state::{PluginStateStorage, FileSystemStateStorage, MemoryStateStorage, PluginStateManager};
 
 /// Plugin metadata containing information about a plugin
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +60,36 @@ pub enum PluginStatus {
     Disabled,
     /// Plugin has failed and needs attention
     Failed,
+    /// Plugin is initializing
+    Initializing,
+    /// Plugin is shutting down
+    ShuttingDown,
+}
+
+/// Plugin initialization error
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    /// Plugin not found
+    #[error("Plugin not found: {0}")]
+    NotFound(Uuid),
+    /// Plugin already registered
+    #[error("Plugin already registered: {0}")]
+    AlreadyRegistered(Uuid),
+    /// Plugin dependency not found
+    #[error("Plugin dependency not found: {0}")]
+    DependencyNotFound(String),
+    /// Plugin dependency cycle detected
+    #[error("Plugin dependency cycle detected: {0}")]
+    DependencyCycle(Uuid),
+    /// Plugin initialization failed
+    #[error("Plugin initialization failed: {0}")]
+    InitializationFailed(String),
+    /// Plugin shutdown failed
+    #[error("Plugin shutdown failed: {0}")]
+    ShutdownFailed(String),
+    /// Plugin state error
+    #[error("Plugin state error: {0}")]
+    StateError(String),
 }
 
 /// Core plugin trait that all plugins must implement
@@ -89,8 +123,59 @@ pub struct PluginManager {
     plugins: Arc<RwLock<HashMap<Uuid, Box<dyn Plugin>>>>,
     /// Plugin status
     status: Arc<RwLock<HashMap<Uuid, PluginStatus>>>,
-    /// Plugin state
-    state: Arc<RwLock<HashMap<Uuid, PluginState>>>,
+    /// Plugin state manager
+    state_manager: PluginStateManager,
+    /// Plugin name to ID mapping
+    name_to_id: Arc<RwLock<HashMap<String, Uuid>>>,
+}
+
+/// Visits a plugin and its dependencies in topological order
+/// 
+/// # Errors
+/// 
+/// Returns an error if a dependency cycle is detected or a dependency is not found
+async fn visit_dependency(
+    id: Uuid,
+    plugins: &HashMap<Uuid, Box<dyn Plugin>>,
+    name_to_id: &HashMap<String, Uuid>,
+    visited: &mut HashSet<Uuid>,
+    temp: &mut HashSet<Uuid>,
+    order: &mut Vec<Uuid>,
+) -> Result<()> {
+    // Check for cycle
+    if temp.contains(&id) {
+        return Err(PluginError::DependencyCycle(id).into());
+    }
+    
+    // If already visited, skip
+    if visited.contains(&id) {
+        return Ok(());
+    }
+    
+    // Mark as temporarily visited
+    temp.insert(id);
+    
+    // Get plugin dependencies
+    let plugin = plugins.get(&id).ok_or(PluginError::NotFound(id))?;
+    let dependencies = &plugin.metadata().dependencies;
+    
+    // Visit all dependencies
+    for dep_name in dependencies {
+        let dep_id = name_to_id.get(dep_name)
+            .ok_or_else(|| PluginError::DependencyNotFound(dep_name.clone()))?;
+        
+        // Box the future to avoid infinitely sized futures due to recursion
+        Box::pin(visit_dependency(*dep_id, plugins, name_to_id, visited, temp, order)).await?;
+    }
+    
+    // Mark as visited
+    temp.remove(&id);
+    visited.insert(id);
+    
+    // Add to order
+    order.push(id);
+    
+    Ok(())
 }
 
 impl PluginManager {
@@ -100,7 +185,33 @@ impl PluginManager {
         Self {
             plugins: Arc::new(RwLock::new(HashMap::new())),
             status: Arc::new(RwLock::new(HashMap::new())),
-            state: Arc::new(RwLock::new(HashMap::new())),
+            state_manager: PluginStateManager::with_memory_storage(),
+            name_to_id: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Create a new plugin manager with file system state storage
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if the base directory for state storage cannot be created or accessed.
+    pub fn with_file_storage(base_dir: std::path::PathBuf) -> Result<Self> {
+        Ok(Self {
+            plugins: Arc::new(RwLock::new(HashMap::new())),
+            status: Arc::new(RwLock::new(HashMap::new())),
+            state_manager: PluginStateManager::with_file_storage(base_dir)?,
+            name_to_id: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Create a new plugin manager with custom state storage
+    #[must_use]
+    pub fn with_state_storage(storage: Box<dyn PluginStateStorage>) -> Self {
+        Self {
+            plugins: Arc::new(RwLock::new(HashMap::new())),
+            status: Arc::new(RwLock::new(HashMap::new())),
+            state_manager: PluginStateManager::new(storage),
+            name_to_id: Arc::new(RwLock::new(HashMap::new())),
         }
     }
     
@@ -113,12 +224,21 @@ impl PluginManager {
     pub async fn register_plugin(&self, plugin: Box<dyn Plugin>) -> Result<()> {
         let metadata = plugin.metadata();
         let id = metadata.id;
+        let name = metadata.name.clone();
         
         let mut plugins = self.plugins.write().await;
         let mut status = self.status.write().await;
+        let mut name_to_id = self.name_to_id.write().await;
+        
+        if plugins.contains_key(&id) {
+            return Err(PluginError::AlreadyRegistered(id).into());
+        }
         
         plugins.insert(id, plugin);
         status.insert(id, PluginStatus::Registered);
+        name_to_id.insert(name, id);
+        
+        debug!("Registered plugin: {}", id);
         
         Ok(())
     }
@@ -134,11 +254,43 @@ impl PluginManager {
         let mut status = self.status.write().await;
         
         if let Some(plugin) = plugins.get(&id) {
-            plugin.initialize().await?;
-            status.insert(id, PluginStatus::Active);
+            let current_status = status.get(&id).copied().unwrap_or(PluginStatus::Registered);
+            
+            if current_status == PluginStatus::Active {
+                debug!("Plugin already active: {}", id);
+                return Ok(());
+            }
+            
+            if current_status == PluginStatus::Initializing {
+                warn!("Plugin already initializing: {}", id);
+                return Ok(());
+            }
+            
+            // Mark as initializing
+            status.insert(id, PluginStatus::Initializing);
+            
+            // Try to load state first
+            if let Err(e) = self.state_manager.load_state(plugin.as_ref()).await {
+                warn!("Failed to load state for plugin {}: {}", id, e);
+                // Continue with initialization even if state loading fails
+            }
+            
+            debug!("Initializing plugin: {}", id);
+            match plugin.initialize().await {
+                Ok(()) => {
+                    status.insert(id, PluginStatus::Active);
+                    info!("Plugin activated: {}", id);
+                    Ok(())
+                }
+                Err(e) => {
+                    status.insert(id, PluginStatus::Failed);
+                    error!("Plugin initialization failed: {}: {}", id, e);
+                    Err(PluginError::InitializationFailed(e.to_string()).into())
+                }
+            }
+        } else {
+            Err(PluginError::NotFound(id).into())
         }
-        
-        Ok(())
     }
     
     /// Unload and shutdown a plugin
@@ -152,11 +304,151 @@ impl PluginManager {
         let mut status = self.status.write().await;
         
         if let Some(plugin) = plugins.get(&id) {
-            plugin.shutdown().await?;
-            status.insert(id, PluginStatus::Disabled);
+            // Check current status
+            let current_status = status.get(&id).copied().unwrap_or(PluginStatus::Registered);
+            
+            if current_status == PluginStatus::Disabled {
+                debug!("Plugin already disabled: {}", id);
+                return Ok(());
+            }
+            
+            if current_status == PluginStatus::ShuttingDown {
+                warn!("Plugin already shutting down: {}", id);
+                return Ok(());
+            }
+            
+            // Mark as shutting down
+            status.insert(id, PluginStatus::ShuttingDown);
+            
+            // Save plugin state before shutdown
+            if let Err(e) = self.state_manager.save_state(plugin.as_ref()).await {
+                warn!("Failed to save state for plugin {}: {}", id, e);
+                // Continue with shutdown even if state saving fails
+            }
+            
+            debug!("Shutting down plugin: {}", id);
+            match plugin.shutdown().await {
+                Ok(()) => {
+                    status.insert(id, PluginStatus::Disabled);
+                    info!("Plugin disabled: {}", id);
+                    Ok(())
+                }
+                Err(e) => {
+                    status.insert(id, PluginStatus::Failed);
+                    error!("Plugin shutdown failed: {}: {}", id, e);
+                    Err(PluginError::ShutdownFailed(e.to_string()).into())
+                }
+            }
+        } else {
+            Err(PluginError::NotFound(id).into())
+        }
+    }
+    
+    /// Resolve plugin dependencies and return load order
+    /// 
+    /// # Errors
+    /// Returns an error if:
+    /// - A dependency is not found
+    /// - A dependency cycle is detected
+    pub async fn resolve_dependencies(&self) -> Result<Vec<Uuid>> {
+        let plugins = self.plugins.read().await;
+        let name_to_id = self.name_to_id.read().await;
+        
+        let mut visited = HashSet::new();
+        let mut temp = HashSet::new();
+        let mut order = Vec::new();
+        
+        // Visit all plugins
+        for (&id, _) in plugins.iter() {
+            if !visited.contains(&id) {
+                visit_dependency(
+                    id, 
+                    &plugins, 
+                    &name_to_id, 
+                    &mut visited, 
+                    &mut temp, 
+                    &mut order
+                ).await?;
+            }
+        }
+        
+        Ok(order)
+    }
+    
+    /// Load all plugins in the correct dependency order
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Plugin dependency resolution fails
+    /// - Plugin initialization fails
+    pub async fn load_all_plugins(&self) -> Result<()> {
+        // Resolve dependencies
+        let order = self.resolve_dependencies().await?;
+        
+        // Load plugins in order
+        for id in order {
+            self.load_plugin(id).await?;
         }
         
         Ok(())
+    }
+    
+    /// Unload all plugins in reverse dependency order
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Plugin dependency resolution fails
+    /// - Plugin shutdown fails
+    pub async fn unload_all_plugins(&self) -> Result<()> {
+        // Resolve dependencies
+        let mut order = self.resolve_dependencies().await?;
+        
+        // Reverse order for shutdown
+        order.reverse();
+        
+        // Unload plugins in reverse order
+        for id in order {
+            self.unload_plugin(id).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Get plugin by ID
+    ///
+    /// # Errors
+    /// Returns an error if the plugin is not found
+    pub async fn get_plugin_by_id<F, R>(&self, id: Uuid, f: F) -> Result<R>
+    where
+        F: FnOnce(&Box<dyn Plugin>) -> R,
+    {
+        self.with_plugin(id, f).await
+    }
+    
+    /// Execute a function with a plugin
+    ///
+    /// # Errors
+    /// Returns an error if the plugin is not found
+    pub async fn with_plugin<F, R>(&self, id: Uuid, f: F) -> Result<R>
+    where
+        F: FnOnce(&Box<dyn Plugin>) -> R,
+    {
+        let plugins = self.plugins.read().await;
+        let plugin = plugins.get(&id).ok_or(PluginError::NotFound(id))?;
+        Ok(f(plugin))
+    }
+    
+    /// Get plugin by name
+    ///
+    /// # Errors
+    /// Returns an error if the plugin is not found
+    pub async fn get_plugin_by_name<F, R>(&self, name: &str, f: F) -> Result<R>
+    where
+        F: FnOnce(&Box<dyn Plugin>) -> R,
+    {
+        let name_to_id = self.name_to_id.read().await;
+        let id = name_to_id.get(name).ok_or_else(|| PluginError::DependencyNotFound(name.to_string()))?;
+        self.with_plugin(*id, f).await
     }
     
     /// Get plugin status
@@ -169,8 +461,13 @@ impl PluginManager {
     /// Get plugin state
     #[must_use]
     pub async fn get_plugin_state(&self, id: Uuid) -> Option<PluginState> {
-        let state = self.state.read().await;
-        state.get(&id).cloned()
+        match self.state_manager.load_plugin_state(id).await {
+            Ok(state) => state,
+            Err(e) => {
+                error!("Failed to load plugin state: {}: {}", id, e);
+                None
+            }
+        }
     }
     
     /// Set plugin state
@@ -180,12 +477,28 @@ impl PluginManager {
     /// - The plugin state update fails
     /// - The plugin is not found
     pub async fn set_plugin_state(&self, state: PluginState) -> Result<()> {
-        let mut states = self.state.write().await;
-        states.insert(state.plugin_id, state);
-        Ok(())
+        self.state_manager.save_plugin_state(&state).await
+    }
+
+    /// Delete plugin state
+    /// 
+    /// # Errors
+    /// Returns an error if:
+    /// - The plugin state deletion fails
+    pub async fn delete_plugin_state(&self, id: Uuid) -> Result<()> {
+        self.state_manager.delete_plugin_state(id).await
+    }
+
+    /// List all plugin states
+    /// 
+    /// # Errors
+    /// Returns an error if the state listing fails
+    pub async fn list_plugin_states(&self) -> Result<Vec<PluginState>> {
+        self.state_manager.list_plugin_states().await
     }
 
     /// Get all active plugins
+    #[must_use]
     pub async fn get_active_plugins(&self) -> Vec<Uuid> {
         let status = self.status.read().await;
         status
@@ -196,9 +509,125 @@ impl PluginManager {
     }
 
     /// Get plugin capabilities
+    #[must_use]
     pub async fn get_plugin_capabilities(&self, id: Uuid) -> Option<Vec<String>> {
         let plugins = self.plugins.read().await;
         plugins.get(&id).map(|plugin| plugin.metadata().capabilities.clone())
+    }
+
+    /// Get plugins by capability
+    #[must_use]
+    pub async fn get_plugins_by_capability(&self, capability: &str) -> Vec<Uuid> {
+        let plugins = self.plugins.read().await;
+        let status = self.status.read().await;
+        
+        plugins
+            .iter()
+            .filter(|(&id, plugin)| {
+                // Check if active and has the capability
+                status.get(&id).copied().unwrap_or(PluginStatus::Registered) == PluginStatus::Active
+                && plugin.metadata().capabilities.contains(&capability.to_string())
+            })
+            .map(|(&id, _)| id)
+            .collect()
+    }
+
+    /// Load state for a specific plugin
+    /// 
+    /// # Errors
+    /// Returns an error if:
+    /// - The plugin is not found
+    /// - The plugin state loading fails
+    pub async fn load_plugin_state(&self, id: Uuid) -> Result<()> {
+        let plugins = self.plugins.read().await;
+        
+        if let Some(plugin) = plugins.get(&id) {
+            self.state_manager.load_state(plugin.as_ref()).await?;
+            debug!("Loaded state for plugin: {}", id);
+            Ok(())
+        } else {
+            Err(PluginError::NotFound(id).into())
+        }
+    }
+
+    /// Save state for a specific plugin
+    /// 
+    /// # Errors
+    /// Returns an error if:
+    /// - The plugin is not found
+    /// - The plugin state saving fails
+    pub async fn save_plugin_state(&self, id: Uuid) -> Result<()> {
+        let plugins = self.plugins.read().await;
+        
+        if let Some(plugin) = plugins.get(&id) {
+            self.state_manager.save_state(plugin.as_ref()).await?;
+            debug!("Saved state for plugin: {}", id);
+            Ok(())
+        } else {
+            Err(PluginError::NotFound(id).into())
+        }
+    }
+
+    /// Load state for all plugins
+    /// 
+    /// # Errors
+    /// Returns an error if any plugin state fails to load
+    pub async fn load_all_plugin_states(&self) -> Result<()> {
+        let plugins = self.plugins.read().await;
+        let plugin_refs: Vec<&dyn Plugin> = plugins.values()
+            .map(std::convert::AsRef::as_ref)
+            .collect();
+        
+        for plugin in plugin_refs {
+            if let Err(e) = self.state_manager.load_state(plugin).await {
+                warn!("Failed to load state for plugin {}: {}", plugin.metadata().id, e);
+            }
+        }
+        
+        info!("Loaded states for all plugins");
+        Ok(())
+    }
+
+    /// Save state for all plugins
+    /// 
+    /// # Errors
+    /// Returns an error if any plugin state fails to save
+    pub async fn save_all_plugin_states(&self) -> Result<()> {
+        let plugins = self.plugins.read().await;
+        let plugin_refs: Vec<&dyn Plugin> = plugins.values()
+            .map(std::convert::AsRef::as_ref)
+            .collect();
+        
+        for plugin in plugin_refs {
+            if let Err(e) = self.state_manager.save_state(plugin).await {
+                warn!("Failed to save state for plugin {}: {}", plugin.metadata().id, e);
+            }
+        }
+        
+        info!("Saved states for all plugins");
+        Ok(())
+    }
+
+    /// Safely shut down the plugin manager, saving all plugin states
+    /// 
+    /// # Errors
+    /// Returns an error if:
+    /// - Plugin dependency resolution fails
+    /// - Plugin shutdown fails
+    pub async fn shutdown(&self) -> Result<()> {
+        // First save all plugin states
+        info!("Saving plugin states before shutdown");
+        if let Err(e) = self.save_all_plugin_states().await {
+            warn!("Error saving plugin states: {}", e);
+            // Continue with shutdown
+        }
+        
+        // Then unload all plugins in reverse dependency order
+        info!("Unloading all plugins");
+        self.unload_all_plugins().await?;
+        
+        info!("Plugin manager shutdown complete");
+        Ok(())
     }
 }
 
@@ -246,65 +675,447 @@ mod tests {
     #[tokio::test]
     async fn test_plugin_lifecycle() {
         let manager = PluginManager::new();
+        let plugin_id = Uuid::new_v4();
+        let state = Arc::new(RwLock::new(None));
+        
         let plugin = TestPlugin {
             metadata: PluginMetadata {
-                id: Uuid::new_v4(),
-                name: "test_plugin".to_string(),
-                version: "1.0.0".to_string(),
+                id: plugin_id,
+                name: "test".to_string(),
+                version: "0.1.0".to_string(),
                 description: "Test plugin".to_string(),
                 author: "Test Author".to_string(),
                 dependencies: vec![],
-                capabilities: vec![],
+                capabilities: vec!["test".to_string()],
             },
-            state: Arc::new(RwLock::new(None)),
+            state: state.clone(),
         };
-        
-        let plugin_id = plugin.metadata().id;
         
         // Register plugin
         manager.register_plugin(Box::new(plugin)).await.unwrap();
-        assert_eq!(manager.get_plugin_status(plugin_id).await, Some(PluginStatus::Registered));
         
-        // Load plugin
-        manager.load_plugin(plugin_id).await.unwrap();
-        assert_eq!(manager.get_plugin_status(plugin_id).await, Some(PluginStatus::Active));
+        // Set initial state
+        let initial_state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"initialized": false}),
+            last_modified: chrono::Utc::now(),
+        };
         
-        // Unload plugin
-        manager.unload_plugin(plugin_id).await.unwrap();
-        assert_eq!(manager.get_plugin_status(plugin_id).await, Some(PluginStatus::Disabled));
+        // Save initial state to storage
+        manager.set_plugin_state(initial_state.clone()).await.unwrap();
+        
+        // Get plugin status
+        let id = manager.name_to_id.read().await.get("test").unwrap().clone();
+        assert_eq!(manager.get_plugin_status(id).await, Some(PluginStatus::Registered));
+        
+        // Load plugin (should load state)
+        manager.load_plugin(id).await.unwrap();
+        assert_eq!(manager.get_plugin_status(id).await, Some(PluginStatus::Active));
+        
+        // Verify state was loaded
+        let loaded_state = state.read().await.clone().expect("State should be loaded");
+        assert_eq!(loaded_state.plugin_id, initial_state.plugin_id);
+        assert_eq!(loaded_state.data, initial_state.data);
+        
+        // Update state
+        let updated_state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"initialized": true}),
+            last_modified: chrono::Utc::now(),
+        };
+        
+        {
+            let mut plugin_state = state.write().await;
+            *plugin_state = Some(updated_state.clone());
+        }
+        
+        // Unload plugin (should save state)
+        manager.unload_plugin(id).await.unwrap();
+        assert_eq!(manager.get_plugin_status(id).await, Some(PluginStatus::Disabled));
+        
+        // Verify state was saved
+        let saved_state = manager.get_plugin_state(id).await.expect("State should be saved");
+        assert_eq!(saved_state.data, updated_state.data);
     }
     
     #[tokio::test]
     async fn test_plugin_state() {
         let manager = PluginManager::new();
+        let plugin_id = Uuid::new_v4();
         let plugin = TestPlugin {
             metadata: PluginMetadata {
-                id: Uuid::new_v4(),
-                name: "test_plugin".to_string(),
-                version: "1.0.0".to_string(),
+                id: plugin_id,
+                name: "test".to_string(),
+                version: "0.1.0".to_string(),
                 description: "Test plugin".to_string(),
                 author: "Test Author".to_string(),
                 dependencies: vec![],
-                capabilities: vec![],
+                capabilities: vec!["test".to_string()],
             },
             state: Arc::new(RwLock::new(None)),
         };
         
-        let plugin_id = plugin.metadata().id;
-        
-        // Register and load plugin
+        // Register plugin
         manager.register_plugin(Box::new(plugin)).await.unwrap();
-        manager.load_plugin(plugin_id).await.unwrap();
         
-        // Set and get state
+        // Set plugin state
         let state = PluginState {
             plugin_id,
             data: serde_json::json!({"key": "value"}),
             last_modified: chrono::Utc::now(),
         };
-        
         manager.set_plugin_state(state.clone()).await.unwrap();
+        
+        // Get plugin state
         let retrieved_state = manager.get_plugin_state(plugin_id).await.unwrap();
         assert_eq!(retrieved_state.plugin_id, state.plugin_id);
+        assert_eq!(retrieved_state.data, state.data);
+    }
+    
+    #[tokio::test]
+    async fn test_dependency_resolution() {
+        let manager = PluginManager::new();
+        
+        // Create plugins with dependencies
+        let plugin_a_id = Uuid::new_v4();
+        let plugin_a = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_a_id,
+                name: "plugin-a".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin A".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["a".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_b_id = Uuid::new_v4();
+        let plugin_b = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_b_id,
+                name: "plugin-b".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin B".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-a".to_string()],
+                capabilities: vec!["b".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_c_id = Uuid::new_v4();
+        let plugin_c = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_c_id,
+                name: "plugin-c".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin C".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-b".to_string()],
+                capabilities: vec!["c".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Register plugins
+        manager.register_plugin(Box::new(plugin_a)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_b)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_c)).await.unwrap();
+        
+        // Resolve dependencies
+        let order = manager.resolve_dependencies().await.unwrap();
+        
+        // Verify order (A -> B -> C)
+        assert_eq!(order.len(), 3);
+        
+        // The plugin with no dependencies should be first
+        assert_eq!(order[0], plugin_a_id);
+        
+        // The plugin that depends on A should be second
+        assert_eq!(order[1], plugin_b_id);
+        
+        // The plugin that depends on B should be last
+        assert_eq!(order[2], plugin_c_id);
+        
+        // Test loading all plugins
+        manager.load_all_plugins().await.unwrap();
+        
+        // Verify all plugins are active
+        assert_eq!(manager.get_plugin_status(plugin_a_id).await, Some(PluginStatus::Active));
+        assert_eq!(manager.get_plugin_status(plugin_b_id).await, Some(PluginStatus::Active));
+        assert_eq!(manager.get_plugin_status(plugin_c_id).await, Some(PluginStatus::Active));
+    }
+    
+    #[tokio::test]
+    async fn test_dependency_cycle() {
+        let manager = PluginManager::new();
+        
+        // Create plugins with a dependency cycle
+        let plugin_a_id = Uuid::new_v4();
+        let plugin_a = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_a_id,
+                name: "plugin-a".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin A".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-c".to_string()],
+                capabilities: vec!["a".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_b_id = Uuid::new_v4();
+        let plugin_b = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_b_id,
+                name: "plugin-b".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin B".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-a".to_string()],
+                capabilities: vec!["b".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_c_id = Uuid::new_v4();
+        let plugin_c = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_c_id,
+                name: "plugin-c".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin C".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-b".to_string()],
+                capabilities: vec!["c".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Register plugins
+        manager.register_plugin(Box::new(plugin_a)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_b)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_c)).await.unwrap();
+        
+        // Resolve dependencies should fail due to cycle
+        let result = manager.resolve_dependencies().await;
+        assert!(result.is_err());
+        
+        // Should be a dependency cycle error
+        match result {
+            Err(e) => {
+                // Convert to string to check the error type
+                let err_str = e.to_string();
+                assert!(err_str.contains("dependency cycle"));
+            },
+            Ok(_) => panic!("Expected dependency cycle error"),
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_get_plugins_by_capability() {
+        let manager = PluginManager::new();
+        
+        // Create plugins with different capabilities
+        let plugin_a_id = Uuid::new_v4();
+        let plugin_a = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_a_id,
+                name: "plugin-a".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin A".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["cap1".to_string(), "cap2".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_b_id = Uuid::new_v4();
+        let plugin_b = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_b_id,
+                name: "plugin-b".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin B".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["cap2".to_string(), "cap3".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Register and activate plugins
+        manager.register_plugin(Box::new(plugin_a)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_b)).await.unwrap();
+        manager.load_plugin(plugin_a_id).await.unwrap();
+        manager.load_plugin(plugin_b_id).await.unwrap();
+        
+        // Get plugins by capability
+        let cap1_plugins = manager.get_plugins_by_capability("cap1").await;
+        let cap2_plugins = manager.get_plugins_by_capability("cap2").await;
+        let cap3_plugins = manager.get_plugins_by_capability("cap3").await;
+        
+        // Verify correct plugins found
+        assert_eq!(cap1_plugins.len(), 1);
+        assert_eq!(cap1_plugins[0], plugin_a_id);
+        
+        assert_eq!(cap2_plugins.len(), 2);
+        assert!(cap2_plugins.contains(&plugin_a_id));
+        assert!(cap2_plugins.contains(&plugin_b_id));
+        
+        assert_eq!(cap3_plugins.len(), 1);
+        assert_eq!(cap3_plugins[0], plugin_b_id);
+    }
+    
+    #[tokio::test]
+    async fn test_plugin_manager_state_persistence() {
+        // Create a plugin manager with memory storage
+        let manager = PluginManager::new();
+        let plugin_id = Uuid::new_v4();
+        let plugin = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_id,
+                name: "stateful-plugin".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin with state".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["test".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Register plugin
+        manager.register_plugin(Box::new(plugin)).await.unwrap();
+        
+        // Create initial state
+        let initial_state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"counter": 1, "name": "initial"}),
+            last_modified: chrono::Utc::now(),
+        };
+        
+        // Set plugin state through plugin instance
+        let plugins = manager.plugins.read().await;
+        let plugin = plugins.get(&plugin_id).unwrap();
+        plugin.set_state(initial_state.clone()).await.unwrap();
+        
+        // Save plugin state using manager
+        manager.save_plugin_state(plugin_id).await.unwrap();
+        
+        // Clear plugin state to verify loading works
+        plugin.set_state(PluginState {
+            plugin_id,
+            data: serde_json::json!({"counter": 0, "name": "cleared"}),
+            last_modified: chrono::Utc::now(),
+        }).await.unwrap();
+        
+        // Load plugin state using manager
+        manager.load_plugin_state(plugin_id).await.unwrap();
+        
+        // Verify state was restored
+        let loaded_state = plugin.get_state().await.unwrap().unwrap();
+        assert_eq!(loaded_state.plugin_id, initial_state.plugin_id);
+        assert_eq!(loaded_state.data, initial_state.data);
+        
+        // Test direct state access
+        let state = manager.get_plugin_state(plugin_id).await.unwrap();
+        assert_eq!(state.data, initial_state.data);
+        
+        // Test state update through manager
+        let updated_state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"counter": 2, "name": "updated"}),
+            last_modified: chrono::Utc::now(),
+        };
+        manager.set_plugin_state(updated_state.clone()).await.unwrap();
+        
+        // Verify state was updated
+        let final_state = manager.get_plugin_state(plugin_id).await.unwrap();
+        assert_eq!(final_state.data, updated_state.data);
+        
+        // Test save/load all states
+        manager.save_all_plugin_states().await.unwrap();
+        manager.load_all_plugin_states().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_plugin_manager_shutdown() {
+        let manager = PluginManager::new();
+        
+        // Create multiple plugins
+        let plugin_a_id = Uuid::new_v4();
+        let plugin_a = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_a_id,
+                name: "plugin-a".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin A".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["a".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        let plugin_b_id = Uuid::new_v4();
+        let plugin_b = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_b_id,
+                name: "plugin-b".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Plugin B".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec!["plugin-a".to_string()],
+                capabilities: vec!["b".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Register plugins
+        manager.register_plugin(Box::new(plugin_a)).await.unwrap();
+        manager.register_plugin(Box::new(plugin_b)).await.unwrap();
+        
+        // Load all plugins
+        manager.load_all_plugins().await.unwrap();
+        
+        // Verify all plugins are active
+        assert_eq!(manager.get_plugin_status(plugin_a_id).await, Some(PluginStatus::Active));
+        assert_eq!(manager.get_plugin_status(plugin_b_id).await, Some(PluginStatus::Active));
+        
+        // Set plugin states
+        manager.set_plugin_state(PluginState {
+            plugin_id: plugin_a_id,
+            data: serde_json::json!({"value": "a-data"}),
+            last_modified: chrono::Utc::now(),
+        }).await.unwrap();
+        
+        manager.set_plugin_state(PluginState {
+            plugin_id: plugin_b_id,
+            data: serde_json::json!({"value": "b-data"}),
+            last_modified: chrono::Utc::now(),
+        }).await.unwrap();
+        
+        // Shut down the plugin manager
+        manager.shutdown().await.unwrap();
+        
+        // Verify all plugins are disabled
+        assert_eq!(manager.get_plugin_status(plugin_a_id).await, Some(PluginStatus::Disabled));
+        assert_eq!(manager.get_plugin_status(plugin_b_id).await, Some(PluginStatus::Disabled));
+        
+        // Verify states exist
+        let states = manager.list_plugin_states().await.unwrap();
+        assert_eq!(states.len(), 2);
+        
+        // Verify specific state values
+        let a_state = manager.get_plugin_state(plugin_a_id).await.unwrap();
+        let b_state = manager.get_plugin_state(plugin_b_id).await.unwrap();
+        
+        assert_eq!(a_state.data["value"], "a-data");
+        assert_eq!(b_state.data["value"], "b-data");
     }
 } 

--- a/crates/app/src/plugin/state.rs
+++ b/crates/app/src/plugin/state.rs
@@ -1,0 +1,467 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::fs;
+use std::sync::Arc;
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+use tracing::{debug, warn};
+use crate::error::Result;
+use super::{Plugin, PluginState};
+
+/// Plugin state storage trait
+#[async_trait]
+pub trait PluginStateStorage: Send + Sync {
+    /// Save plugin state
+    async fn save_state(&self, state: &PluginState) -> Result<()>;
+    
+    /// Load plugin state
+    async fn load_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>>;
+    
+    /// Delete plugin state
+    async fn delete_state(&self, plugin_id: Uuid) -> Result<()>;
+    
+    /// List all plugin states
+    async fn list_states(&self) -> Result<Vec<PluginState>>;
+}
+
+/// File system plugin state storage
+#[derive(Debug, Clone)]
+pub struct FileSystemStateStorage {
+    /// Base directory for plugin state
+    base_dir: PathBuf,
+}
+
+impl FileSystemStateStorage {
+    /// Create a new file system state storage
+    #[must_use]
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+    
+    /// Get state file path for a plugin
+    fn get_state_path(&self, plugin_id: Uuid) -> PathBuf {
+        self.base_dir.join(format!("{plugin_id}.json"))
+    }
+}
+
+#[async_trait]
+impl PluginStateStorage for FileSystemStateStorage {
+    async fn save_state(&self, state: &PluginState) -> Result<()> {
+        let path = self.get_state_path(state.plugin_id);
+        
+        // Create directory if it doesn't exist
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        
+        // Serialize state to JSON
+        let json = serde_json::to_string_pretty(state)?;
+        
+        // Write to file
+        fs::write(path, json)?;
+        
+        debug!("Saved plugin state: {}", state.plugin_id);
+        
+        Ok(())
+    }
+    
+    async fn load_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>> {
+        let path = self.get_state_path(plugin_id);
+        
+        if !path.exists() {
+            debug!("Plugin state not found: {}", plugin_id);
+            return Ok(None);
+        }
+        
+        // Read file content
+        let content = fs::read_to_string(path)?;
+        
+        // Deserialize from JSON
+        let state: PluginState = serde_json::from_str(&content)?;
+        
+        debug!("Loaded plugin state: {}", plugin_id);
+        
+        Ok(Some(state))
+    }
+    
+    async fn delete_state(&self, plugin_id: Uuid) -> Result<()> {
+        let path = self.get_state_path(plugin_id);
+        
+        if path.exists() {
+            fs::remove_file(path)?;
+            debug!("Deleted plugin state: {}", plugin_id);
+        }
+        
+        Ok(())
+    }
+    
+    async fn list_states(&self) -> Result<Vec<PluginState>> {
+        let mut states = Vec::new();
+        
+        if !self.base_dir.exists() {
+            return Ok(states);
+        }
+        
+        for entry in fs::read_dir(&self.base_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            
+            if path.is_file() && path.extension().is_some_and(|ext| ext == "json") {
+                // Read and parse file
+                let content = fs::read_to_string(&path)?;
+                match serde_json::from_str::<PluginState>(&content) {
+                    Ok(state) => states.push(state),
+                    Err(e) => warn!("Failed to parse plugin state: {:?} - {}", path, e),
+                }
+            }
+        }
+        
+        Ok(states)
+    }
+}
+
+/// Memory plugin state storage for testing
+#[derive(Debug)]
+pub struct MemoryStateStorage {
+    /// In-memory state storage
+    states: Arc<RwLock<HashMap<Uuid, PluginState>>>,
+}
+
+impl MemoryStateStorage {
+    /// Create a new memory state storage
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            states: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl PluginStateStorage for MemoryStateStorage {
+    async fn save_state(&self, state: &PluginState) -> Result<()> {
+        let mut states = self.states.write().await;
+        states.insert(state.plugin_id, state.clone());
+        Ok(())
+    }
+    
+    async fn load_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>> {
+        let states = self.states.read().await;
+        Ok(states.get(&plugin_id).cloned())
+    }
+    
+    async fn delete_state(&self, plugin_id: Uuid) -> Result<()> {
+        let mut states = self.states.write().await;
+        states.remove(&plugin_id);
+        Ok(())
+    }
+    
+    async fn list_states(&self) -> Result<Vec<PluginState>> {
+        let states = self.states.read().await;
+        Ok(states.values().cloned().collect())
+    }
+}
+
+impl Default for MemoryStateStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Plugin state manager for handling state persistence
+pub struct PluginStateManager {
+    /// State storage
+    storage: Box<dyn PluginStateStorage>,
+}
+
+// Manual Debug implementation since we can't derive it for Box<dyn PluginStateStorage>
+impl std::fmt::Debug for PluginStateManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginStateManager")
+            .field("storage", &"Box<dyn PluginStateStorage>")
+            .finish()
+    }
+}
+
+impl PluginStateManager {
+    /// Create a new plugin state manager
+    #[must_use]
+    pub fn new(storage: Box<dyn PluginStateStorage>) -> Self {
+        Self { storage }
+    }
+    
+    /// Create a new plugin state manager with file system storage
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if the base directory cannot be created or accessed.
+    pub fn with_file_storage(base_dir: PathBuf) -> Result<Self> {
+        // Create directory if it doesn't exist
+        if !base_dir.exists() {
+            fs::create_dir_all(&base_dir)?;
+        }
+        
+        Ok(Self {
+            storage: Box::new(FileSystemStateStorage::new(base_dir)),
+        })
+    }
+    
+    /// Create a new plugin state manager with memory storage
+    #[must_use]
+    pub fn with_memory_storage() -> Self {
+        Self {
+            storage: Box::new(MemoryStateStorage::new()),
+        }
+    }
+    
+    /// Save plugin state
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if saving the state fails due to serialization or storage issues.
+    pub async fn save_state(&self, plugin: &dyn Plugin) -> Result<()> {
+        if let Ok(Some(state)) = plugin.get_state().await {
+            self.storage.save_state(&state).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Load plugin state
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if loading the state fails due to deserialization or storage issues.
+    pub async fn load_state(&self, plugin: &dyn Plugin) -> Result<()> {
+        let plugin_id = plugin.metadata().id;
+        
+        if let Some(state) = self.storage.load_state(plugin_id).await? {
+            plugin.set_state(state).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Delete plugin state
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if deleting the state fails due to storage issues.
+    pub async fn delete_state(&self, plugin_id: Uuid) -> Result<()> {
+        self.storage.delete_state(plugin_id).await
+    }
+    
+    /// Save states for all plugins
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if saving any plugin state fails.
+    pub async fn save_all_states(&self, plugins: &[Box<dyn Plugin>]) -> Result<()> {
+        for plugin in plugins {
+            self.save_state(plugin.as_ref()).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Load states for all plugins
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if loading any plugin state fails.
+    pub async fn load_all_states(&self, plugins: &[Box<dyn Plugin>]) -> Result<()> {
+        for plugin in plugins {
+            self.load_state(plugin.as_ref()).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Save plugin state directly
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if saving the state fails due to serialization or storage issues.
+    pub async fn save_plugin_state(&self, state: &PluginState) -> Result<()> {
+        self.storage.save_state(state).await
+    }
+    
+    /// Load plugin state directly
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if loading the state fails due to deserialization or storage issues.
+    pub async fn load_plugin_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>> {
+        self.storage.load_state(plugin_id).await
+    }
+    
+    /// Delete plugin state directly
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if deleting the state fails due to storage issues.
+    pub async fn delete_plugin_state(&self, plugin_id: Uuid) -> Result<()> {
+        self.storage.delete_state(plugin_id).await
+    }
+    
+    /// List all plugin states
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if listing the states fails due to storage issues.
+    pub async fn list_plugin_states(&self) -> Result<Vec<PluginState>> {
+        self.storage.list_states().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use crate::plugin::{Plugin, PluginMetadata, PluginState};
+    
+    #[derive(Debug)]
+    struct TestPlugin {
+        metadata: PluginMetadata,
+        state: Arc<RwLock<Option<PluginState>>>,
+    }
+    
+    #[async_trait]
+    impl Plugin for TestPlugin {
+        fn metadata(&self) -> &PluginMetadata {
+            &self.metadata
+        }
+        
+        async fn initialize(&self) -> Result<()> {
+            Ok(())
+        }
+        
+        async fn shutdown(&self) -> Result<()> {
+            Ok(())
+        }
+        
+        async fn get_state(&self) -> Result<Option<PluginState>> {
+            Ok(self.state.read().await.clone())
+        }
+        
+        async fn set_state(&self, state: PluginState) -> Result<()> {
+            *self.state.write().await = Some(state);
+            Ok(())
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_memory_state_storage() {
+        let storage = MemoryStateStorage::new();
+        
+        // Create a test state
+        let plugin_id = Uuid::new_v4();
+        let state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"key": "value"}),
+            last_modified: Utc::now(),
+        };
+        
+        // Save state
+        storage.save_state(&state).await.unwrap();
+        
+        // Load state
+        let loaded_state = storage.load_state(plugin_id).await.unwrap().unwrap();
+        
+        // Verify
+        assert_eq!(loaded_state.plugin_id, state.plugin_id);
+        assert_eq!(loaded_state.data, state.data);
+        
+        // Delete state
+        storage.delete_state(plugin_id).await.unwrap();
+        
+        // Verify deleted
+        let deleted_state = storage.load_state(plugin_id).await.unwrap();
+        assert!(deleted_state.is_none());
+    }
+    
+    #[tokio::test]
+    async fn test_plugin_state_manager() {
+        let manager = PluginStateManager::with_memory_storage();
+        
+        // Create a test plugin
+        let plugin_id = Uuid::new_v4();
+        let plugin = TestPlugin {
+            metadata: PluginMetadata {
+                id: plugin_id,
+                name: "test".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Test plugin".to_string(),
+                author: "Test Author".to_string(),
+                dependencies: vec![],
+                capabilities: vec!["test".to_string()],
+            },
+            state: Arc::new(RwLock::new(None)),
+        };
+        
+        // Create a test state
+        let state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"key": "value"}),
+            last_modified: Utc::now(),
+        };
+        
+        // Set plugin state
+        plugin.set_state(state.clone()).await.unwrap();
+        
+        // Save state
+        manager.save_state(&plugin).await.unwrap();
+        
+        // Clear plugin state
+        *plugin.state.write().await = None;
+        
+        // Load state
+        manager.load_state(&plugin).await.unwrap();
+        
+        // Verify state was loaded
+        let loaded_state = plugin.get_state().await.unwrap().unwrap();
+        assert_eq!(loaded_state.plugin_id, state.plugin_id);
+        assert_eq!(loaded_state.data, state.data);
+    }
+    
+    #[tokio::test]
+    async fn test_file_system_state_storage() {
+        // Create a temporary directory
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = FileSystemStateStorage::new(temp_dir.path().to_path_buf());
+        
+        // Create a test state
+        let plugin_id = Uuid::new_v4();
+        let state = PluginState {
+            plugin_id,
+            data: serde_json::json!({"key": "value"}),
+            last_modified: Utc::now(),
+        };
+        
+        // Save state
+        storage.save_state(&state).await.unwrap();
+        
+        // Verify file exists
+        let state_path = storage.get_state_path(plugin_id);
+        assert!(state_path.exists());
+        
+        // Load state
+        let loaded_state = storage.load_state(plugin_id).await.unwrap().unwrap();
+        
+        // Verify
+        assert_eq!(loaded_state.plugin_id, state.plugin_id);
+        assert_eq!(loaded_state.data, state.data);
+        
+        // Delete state
+        storage.delete_state(plugin_id).await.unwrap();
+        
+        // Verify file deleted
+        assert!(!state_path.exists());
+    }
+} 

--- a/specs/app/core-priorities.md
+++ b/specs/app/core-priorities.md
@@ -1,6 +1,6 @@
 ---
 version: 1.2.0
-last_updated: 2024-03-15
+last_updated: 2024-03-25
 status: active
 priority: high
 ---
@@ -17,6 +17,8 @@ priority: high
 - ✅ Thread safety
 - ✅ Performance monitoring
 - ✅ Test coverage
+- ✅ Command history
+- ✅ Command suggestions
 
 ### 2. Validation System (100% Complete)
 - ✅ Validation rules framework
@@ -27,22 +29,33 @@ priority: high
 - ✅ Error propagation
 - ✅ Test coverage
 
-### 3. Integration Features (75% Complete)
+### 3. Integration Features (85% Complete)
 - ✅ UI system integration
 - ✅ MCP protocol support
-- 🔄 Plugin system
+- ✅ Plugin system core
+- 🔄 Plugin system extensions
 - 🔄 Event system
 - 📅 External tool integration
 
 ## Recent Achievements
 
-### Validation System
-- Implemented comprehensive validation framework
-- Added thread-safe validation context
-- Created extensive test suite
-- Achieved 100% test coverage
-- Implemented resource monitoring
-- Added security features
+### Command System
+- Implemented comprehensive command history
+- Added thread-safe history tracking
+- Created history search functionality
+- Added command suggestions
+- Implemented pattern-based suggestions
+- Added suggestion metadata support
+- Implemented test coverage
+
+### Plugin System
+- Implemented core plugin architecture
+- Added plugin lifecycle management
+- Created plugin discovery system
+- Added plugin state management
+- Implemented plugin types (Command, UI, Tool, MCP)
+- Added plugin validation
+- Created test coverage
 
 ### Testing Improvements
 - Added concurrent operation tests
@@ -54,7 +67,7 @@ priority: high
 ## Next Steps
 
 ### Week 1-2
-1. Complete plugin system integration
+1. Complete plugin system extensions
 2. Enhance event system
 3. Add external tool support
 4. Optimize performance

--- a/specs/plugins/ASYNC_MUTEX_REFACTORING.md
+++ b/specs/plugins/ASYNC_MUTEX_REFACTORING.md
@@ -1,0 +1,296 @@
+---
+description: Specification for refactoring mutex usage in the plugin system
+authors: DataScienceBioLab
+status: Draft
+priority: High
+---
+
+# Plugin System Async Mutex Refactoring Specification
+
+## Problem Statement
+
+The current implementation of the plugin system uses standard synchronous mutexes (`std::sync::Mutex`, `RwLock`) in combination with async code. Clippy has identified several instances where `MutexGuard` values are held across `.await` points, which can lead to blocking issues, potential deadlocks, and overall performance degradation in an asynchronous environment.
+
+The pattern we need to address is found in several key components of the plugin system, particularly in the `PluginManager` class which manages plugin lifecycle and state persistence. These issues could impact the overall responsiveness of the application, especially under high load or when many plugins are in use.
+
+## Goals
+
+- Replace standard synchronous mutexes with async-aware alternatives where appropriate
+- Eliminate all instances of holding mutex guards across await points
+- Maintain thread safety and data integrity
+- Improve overall performance in async contexts
+- Preserve existing API surface where possible
+- Ensure proper state persistence for plugins
+
+## Technical Approach
+
+### Current Implementation Analysis
+
+The current implementation mixes synchronous locking primitives with asynchronous code:
+
+```rust
+// Example from mod.rs in PluginManager
+pub async fn load_plugin(&self, id: Uuid) -> Result<()> {
+    let plugins = self.plugins.read().await;
+    let mut status = self.status.write().await;
+    
+    if let Some(plugin) = plugins.get(&id) {
+        // ... status checks ...
+        
+        // Mark as initializing
+        status.insert(id, PluginStatus::Initializing);
+        
+        // Try to load state first - MutexGuard held across await
+        if let Err(e) = self.state_manager.load_state(plugin.as_ref()).await {
+            warn!("Failed to load state for plugin {}: {}", id, e);
+        }
+        
+        // Initialize plugin - MutexGuard held across await
+        match plugin.initialize().await {
+            Ok(()) => {
+                status.insert(id, PluginStatus::Active);
+                info!("Plugin activated: {}", id);
+                Ok(())
+            }
+            Err(e) => {
+                // ... error handling ...
+            }
+        }
+    } else {
+        Err(PluginError::NotFound(id).into())
+    }
+}
+```
+
+This pattern appears in multiple places throughout the plugin system codebase and creates potential issues.
+
+### Proposed Solution
+
+Replace standard synchronous mutexes with async-aware alternatives:
+
+1. Use `tokio::sync::Mutex` instead of `std::sync::Mutex`
+2. Use `tokio::sync::RwLock` instead of `std::sync::RwLock`
+3. Restructure code to avoid holding locks across await points
+4. Optimize lock usage to minimize contention
+
+#### Example Refactoring Pattern
+
+Before:
+```rust
+pub async fn load_plugin(&self, id: Uuid) -> Result<()> {
+    let plugins = self.plugins.read().await;
+    let mut status = self.status.write().await;
+    
+    if let Some(plugin) = plugins.get(&id) {
+        // ... operations ...
+        // MutexGuard held across multiple await points
+        self.state_manager.load_state(plugin.as_ref()).await?;
+        plugin.initialize().await?;
+    }
+}
+```
+
+After:
+```rust
+pub async fn load_plugin(&self, id: Uuid) -> Result<()> {
+    // First check and get the plugin reference without holding locks across await points
+    let plugin = {
+        let plugins = self.plugins.read().await;
+        if let Some(plugin) = plugins.get(&id) {
+            // Clone or get a reference that can be used outside the lock
+            plugin.clone()
+        } else {
+            return Err(PluginError::NotFound(id).into());
+        }
+    };
+    
+    // Update status with minimal lock duration
+    {
+        let mut status = self.status.write().await;
+        status.insert(id, PluginStatus::Initializing);
+    }
+    
+    // Perform async operations without holding locks
+    if let Err(e) = self.state_manager.load_state(plugin.as_ref()).await {
+        warn!("Failed to load state for plugin {}: {}", id, e);
+    }
+    
+    // Initialize plugin without holding any locks
+    match plugin.initialize().await {
+        Ok(()) => {
+            // Update status again with minimal lock duration
+            {
+                let mut status = self.status.write().await;
+                status.insert(id, PluginStatus::Active);
+            }
+            info!("Plugin activated: {}", id);
+            Ok(())
+        }
+        Err(e) => {
+            // Handle error and update status
+            // ...
+        }
+    }
+}
+```
+
+## Implementation Strategy
+
+This section outlines the approach to refactoring the plugin system:
+
+### Key Components to Refactor
+
+1. **PluginManager**:
+   - Replace all instances of `std::sync::RwLock` with `tokio::sync::RwLock`
+   - Refactor methods that hold locks across await points
+   - Optimize locking patterns for state persistence operations
+
+2. **Plugin State Manager**:
+   - Refactor state loading and saving operations
+   - Ensure locks are not held during I/O operations
+   - Optimize concurrent state management
+
+3. **Plugin Discovery and Loaders**:
+   - Update any synchronous locks in the discovery process
+   - Ensure proper async patterns in plugin loading
+
+### Specific Refactoring Targets
+
+1. **PluginManager methods to refactor**:
+   - `register_plugin`
+   - `load_plugin`
+   - `unload_plugin`
+   - `resolve_dependencies`
+   - `load_all_plugins`
+   - `unload_all_plugins`
+   - `get_plugin_by_id`
+   - `with_plugin`
+   - All state-related methods
+
+2. **PluginStateManager methods to refactor**:
+   - `save_state`
+   - `load_state`
+   - `save_all_states`
+   - `load_all_states`
+
+### Implementation Steps
+
+1. **Analysis Phase**:
+   - Identify all instances of `std::sync` mutex usage
+   - Map dependencies between components
+   - Identify high-contention areas
+
+2. **Refactoring Phase**:
+   - Replace mutex types with async equivalents
+   - Refactor method implementations to avoid holding locks across await points
+   - Update API signatures if needed
+   - Add proper documentation
+
+3. **Testing Phase**:
+   - Create comprehensive tests for concurrency
+   - Ensure state persistence works correctly
+   - Validate lifecycle management under concurrent load
+   - Performance testing
+
+4. **Documentation and Cleanup**:
+   - Update API documentation
+   - Add comments about locking patterns
+   - Remove unnecessary locks or simplify locking patterns
+
+## Implementation Best Practices
+
+When refactoring to use async mutexes, consider these best practices specific to the plugin system:
+
+1. **Plugin State Management**: Ensure state is properly persisted without holding locks:
+
+```rust
+// Bad: Holding lock during async persistence
+let plugins = self.plugins.read().await;
+if let Some(plugin) = plugins.get(&id) {
+    self.state_manager.load_state(plugin.as_ref()).await?;
+}
+
+// Good: Minimal lock holding
+let plugin = {
+    let plugins = self.plugins.read().await;
+    plugins.get(&id).cloned()
+};
+if let Some(plugin) = plugin {
+    self.state_manager.load_state(plugin.as_ref()).await?;
+}
+```
+
+2. **Plugin Dependencies**: When resolving dependencies, avoid recursive locking:
+
+```rust
+// Use a two-phase approach for dependency resolution
+// 1. Collect all information needed with minimal lock duration
+let dependency_info = {
+    let plugins = self.plugins.read().await;
+    let name_to_id = self.name_to_id.read().await;
+    // Collect needed info without holding locks across await points
+    collect_dependency_info(&plugins, &name_to_id)
+};
+
+// 2. Process dependencies without holding locks
+resolve_dependencies(dependency_info).await
+```
+
+3. **Plugin Lifecycle Management**: Keep locks focused on specific operations:
+
+```rust
+// For operations affecting multiple plugins, use a phased approach:
+
+// 1. Identify affected plugins with read lock
+let affected_plugins = {
+    let plugins = self.plugins.read().await;
+    identify_affected_plugins(&plugins, criteria)
+};
+
+// 2. Perform operations on each plugin without holding global locks
+for plugin_id in affected_plugins {
+    // Use per-plugin locking or process sequentially
+    self.process_plugin(plugin_id).await?;
+}
+```
+
+## Testing Requirements
+
+To ensure the refactored code works correctly, implement comprehensive tests:
+
+1. **Concurrency Tests**:
+   - Test multiple plugins loading/unloading concurrently
+   - Test state persistence under concurrent operations
+   - Test dependency resolution with concurrent updates
+
+2. **Performance Tests**:
+   - Benchmark plugin load times before and after refactoring
+   - Measure throughput for concurrent plugin operations
+   - Test system under high load
+
+3. **Edge Case Tests**:
+   - Test behavior when plugins fail to initialize
+   - Test error handling during concurrent operations
+   - Test recovery from interrupted operations
+
+## Backward Compatibility
+
+The refactoring should maintain the same API surface where possible. Areas to consider:
+
+1. **Plugin Trait**: Ensure the Plugin trait remains unchanged
+2. **PluginManager Interface**: Preserve method signatures and behavior
+3. **Error Handling**: Maintain consistent error types and patterns
+
+## Future Considerations
+
+After the initial refactoring, consider these future improvements:
+
+1. **Fine-grained Locking**: Instead of locking the entire plugin collection, implement more targeted locking strategies
+2. **Lock-free Data Structures**: Evaluate whether some components could use lock-free alternatives
+3. **Parallel Plugin Loading**: Implement parallel loading of independent plugins
+
+## Conclusion
+
+Refactoring the mutex usage in the plugin system to use async-aware alternatives will enhance the robustness and performance of the application, especially in high-concurrency scenarios. The strategy focuses on replacing synchronous locks with async alternatives while ensuring locks are not held across await points.
+
+The implementation will maintain backward compatibility while improving reliability and performance of plugin operations, particularly for systems with many plugins or high concurrency. 

--- a/specs/plugins/README.md
+++ b/specs/plugins/README.md
@@ -42,11 +42,15 @@ The plugin system enables extensibility of the Groundhog AI Coding Assistant thr
 - Startup impact: < 200ms
 
 ## Detailed Specifications
-- [Architecture](architecture.md)
-- [Plugin API](api.md)
-- [Security Model](security.md)
-- [Development Guide](development.md)
-- [Testing](testing.md)
+- [Architecture](plugin-system.md)
+- [Core Plugins](core-plugins.md)
+- [UI Plugins](ui-plugins.md)
+- [MCP Plugins](mcp-plugins.md)
+- [Tool Plugins](tool-plugins.md)
+- [State Persistence](plugin-state-persistence.md)
+- [Security Model](security.md) *(Todo)*
+- [Development Guide](development.md) *(Todo)*
+- [Testing](testing.md) *(Todo)*
 
 ## Plugin Categories
 1. Language Support

--- a/specs/plugins/REVIEW.md
+++ b/specs/plugins/REVIEW.md
@@ -26,6 +26,7 @@ The plugin system specifications are approximately 40% complete, with well-struc
 | [ui-plugins.md](ui-plugins.md) | ✅ Complete | UI plugin types and implementation details |
 | [mcp-plugins.md](mcp-plugins.md) | 🔄 Partial | MCP plugin types (missing implementation details) |
 | [tool-plugins.md](tool-plugins.md) | 🔄 Partial | Tool plugin types (missing implementation details) |
+| [plugin-state-persistence.md](plugin-state-persistence.md) | ✅ Complete | State persistence architecture and implementation details |
 | [security.md](security.md) | ❌ Missing | Security model for the plugin system |
 | [testing.md](testing.md) | ❌ Missing | Testing requirements and strategies |
 | [development.md](development.md) | ❌ Missing | Development guidelines and best practices |

--- a/specs/plugins/plugin-state-persistence.md
+++ b/specs/plugins/plugin-state-persistence.md
@@ -1,0 +1,282 @@
+# Plugin State Persistence Specification
+
+## Overview
+The plugin state persistence system provides a flexible framework for storing and retrieving plugin state across application sessions. It enables plugins to maintain their state between application restarts and ensures data consistency.
+
+## Team Responsibilities
+
+### Core Team (src/core)
+- Plugin state persistence architecture and interfaces
+- State storage implementations
+- State serialization and deserialization
+- State versioning and migration
+- State security and validation
+
+## Plugin State Architecture
+
+### Core Components
+
+1. Plugin State Storage
+   - File system storage
+   - Memory storage (for testing)
+   - Database storage (future)
+   - Cloud storage (future)
+
+2. Plugin State Manager
+   - State serialization
+   - State loading
+   - State saving
+   - State deletion
+   - State listing
+
+3. Plugin State Interface
+   - State retrieval
+   - State updating
+   - State validation
+   - State versioning
+   - State migration
+
+## Implementation Details
+
+### Plugin State Storage Interface
+```rust
+#[async_trait]
+pub trait PluginStateStorage: Send + Sync {
+    /// Save plugin state
+    async fn save_state(&self, state: &PluginState) -> Result<()>;
+    
+    /// Load plugin state
+    async fn load_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>>;
+    
+    /// Delete plugin state
+    async fn delete_state(&self, plugin_id: Uuid) -> Result<()>;
+    
+    /// List all plugin states
+    async fn list_states(&self) -> Result<Vec<PluginState>>;
+}
+```
+
+### Plugin State Structure
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginState {
+    /// Plugin ID
+    pub plugin_id: Uuid,
+    /// State data
+    pub data: serde_json::Value,
+    /// Last modified timestamp
+    pub last_modified: chrono::DateTime<chrono::Utc>,
+}
+```
+
+### Plugin State Manager
+```rust
+pub struct PluginStateManager {
+    /// State storage
+    storage: Box<dyn PluginStateStorage>,
+}
+
+impl PluginStateManager {
+    /// Create a new plugin state manager
+    pub fn new(storage: Box<dyn PluginStateStorage>) -> Self;
+    
+    /// Create a new plugin state manager with file system storage
+    pub fn with_file_storage(base_dir: PathBuf) -> Result<Self>;
+    
+    /// Create a new plugin state manager with memory storage
+    pub fn with_memory_storage() -> Self;
+    
+    /// Save plugin state
+    pub async fn save_state(&self, plugin: &dyn Plugin) -> Result<()>;
+    
+    /// Load plugin state
+    pub async fn load_state(&self, plugin: &dyn Plugin) -> Result<()>;
+    
+    /// Delete plugin state
+    pub async fn delete_state(&self, plugin_id: Uuid) -> Result<()>;
+    
+    /// Save states for all plugins
+    pub async fn save_all_states(&self, plugins: &[Box<dyn Plugin>]) -> Result<()>;
+    
+    /// Load states for all plugins
+    pub async fn load_all_states(&self, plugins: &[Box<dyn Plugin>]) -> Result<()>;
+    
+    /// Save plugin state directly
+    pub async fn save_plugin_state(&self, state: &PluginState) -> Result<()>;
+    
+    /// Load plugin state directly
+    pub async fn load_plugin_state(&self, plugin_id: Uuid) -> Result<Option<PluginState>>;
+    
+    /// Delete plugin state directly
+    pub async fn delete_plugin_state(&self, plugin_id: Uuid) -> Result<()>;
+    
+    /// List all plugin states
+    pub async fn list_plugin_states(&self) -> Result<Vec<PluginState>>;
+}
+```
+
+### Plugin Manager Integration
+```rust
+impl PluginManager {
+    /// Create a new plugin manager with file system state storage
+    pub fn with_file_storage(base_dir: std::path::PathBuf) -> Result<Self>;
+
+    /// Create a new plugin manager with custom state storage
+    pub fn with_state_storage(storage: Box<dyn PluginStateStorage>) -> Self;
+    
+    /// Get plugin state
+    pub async fn get_plugin_state(&self, id: Uuid) -> Option<PluginState>;
+    
+    /// Set plugin state
+    pub async fn set_plugin_state(&self, state: PluginState) -> Result<()>;
+    
+    /// Delete plugin state
+    pub async fn delete_plugin_state(&self, id: Uuid) -> Result<()>;
+    
+    /// List all plugin states
+    pub async fn list_plugin_states(&self) -> Result<Vec<PluginState>>;
+    
+    /// Load state for a specific plugin
+    pub async fn load_plugin_state(&self, id: Uuid) -> Result<()>;
+    
+    /// Save state for a specific plugin
+    pub async fn save_plugin_state(&self, id: Uuid) -> Result<()>;
+    
+    /// Load state for all plugins
+    pub async fn load_all_plugin_states(&self) -> Result<()>;
+    
+    /// Save state for all plugins
+    pub async fn save_all_plugin_states(&self) -> Result<()>;
+    
+    /// Safely shut down the plugin manager, saving all plugin states
+    pub async fn shutdown(&self) -> Result<()>;
+}
+```
+
+## Storage Implementations
+
+### FileSystemStateStorage
+- Base directory configuration
+- JSON serialization and deserialization
+- File I/O operations
+- Error handling
+- File path management
+
+### MemoryStateStorage
+- In-memory state storage
+- Thread-safe access
+- Transient state (for testing)
+- No persistence between application restarts
+- High-performance operations
+
+## Implementation Status
+
+### Core Team (src/core) - 90% Complete
+- [x] Plugin state persistence architecture
+- [x] Plugin state structure
+- [x] Plugin state manager
+- [x] File system storage implementation
+- [x] Memory storage implementation
+- [x] Plugin manager integration
+- [ ] Database storage implementation
+- [ ] Cloud storage implementation
+- [ ] State versioning and migration
+
+## Security Model
+
+### Data Security
+- File permissions
+- Encrypted storage (future)
+- Access control
+- Data validation
+- Error handling
+
+### State Validation
+- Schema validation
+- Size limits
+- Type checking
+- Reference validation
+- Security scanning
+
+## Performance Requirements
+
+### Response Times
+- State save: < 10ms
+- State load: < 10ms
+- State delete: < 5ms
+- State list: < 20ms
+
+### Resource Limits
+- Memory: < 5MB per plugin state
+- Storage: < 10MB per plugin state
+
+## Error Handling
+
+### Error Types
+- Storage errors
+- Serialization errors
+- Validation errors
+- Permission errors
+- Version incompatibility errors
+
+### Recovery Strategies
+- Automatic retry
+- Fallback to default state
+- Error reporting
+- State backup and restoration
+- Graceful degradation
+
+## Testing Requirements
+
+### Unit Tests
+- Storage implementation tests
+- State manager tests
+- Plugin manager integration tests
+- Error handling tests
+- Performance tests
+
+### Integration Tests
+- Cross-plugin state tests
+- Application lifecycle tests
+- Stress tests
+- Recovery tests
+- Security tests
+
+## Next Steps
+
+### Short Term (2 Weeks)
+1. Add state versioning and migration
+2. Implement database storage
+3. Add more comprehensive tests
+4. Enhance error handling and recovery
+5. Document APIs and usage
+
+### Medium Term (2 Months)
+1. Implement encrypted storage
+2. Add cloud storage support
+3. Optimize performance
+4. Enhance security
+5. Add state analytics
+
+### Long Term (6 Months)
+1. Add state synchronization
+2. Implement distributed state
+3. Add AI-powered state analysis
+4. Optimize for large-scale deployments
+5. Add state management UI
+
+## Success Criteria
+
+### Functional Requirements
+- State persistence across application restarts
+- Multiple storage backend support
+- Proper error handling and recovery
+- State versioning and migration
+- Secure storage and access
+
+### Non-Functional Requirements
+- State operations complete within response time limits
+- State storage respects resource limits
+- Secure state storage
+- Complete documentation
+- Comprehensive test coverage 

--- a/specs/plugins/plugin-system.md
+++ b/specs/plugins/plugin-system.md
@@ -97,12 +97,12 @@ The plugin system enables extensibility across all major components of the Groun
 
 ## Implementation Status
 
-### Core Team (src/core) - 30% Complete
+### Core Team (src/core) - 40% Complete
 - [x] Basic plugin system architecture
 - [x] Plugin lifecycle management
 - [x] Basic security model
 - [ ] Advanced dependency resolution
-- [ ] State management system
+- [x] State management system
 - [ ] Error recovery system
 - [ ] Performance optimization
 - [ ] Security hardening


### PR DESCRIPTION
…ng spec - Added #[allow(dead_code)] attributes to suppress warnings for unused fields and methods in discovery.rs - Created comprehensive specification for async mutex refactoring in plugin system - Fixed Clippy warnings across plugin system code - Documented plugin state manager requirements and implementation - Ensured all tests are passing after code changes State: InProgress Components: app/plugins, specs/plugins